### PR TITLE
Adding set-permissions

### DIFF
--- a/docker_agent_workflow.cwl
+++ b/docker_agent_workflow.cwl
@@ -30,6 +30,20 @@ outputs: []
 
 steps:
 
+  set_permissions:
+    run: set_permissions.cwl
+    in:
+      - id: entityid
+        source: "#submitterUploadSynId"
+      # Must update the principal id here
+      - id: principalid
+        valueFrom: "3379097"
+      - id: permissions
+        valueFrom: "download"
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: []
+
   notify_participants:
     run: notification_email.cwl
     in:

--- a/ladder_scoring_harness_workflow.cwl
+++ b/ladder_scoring_harness_workflow.cwl
@@ -31,6 +31,21 @@ inputs:
 outputs: []
 
 steps:
+
+  set_permissions:
+    run: set_permissions.cwl
+    in:
+      - id: entityid
+        source: "#submitterUploadSynId"
+      # Must update the principal id here
+      - id: principalid
+        valueFrom: "3379097"
+      - id: permissions
+        valueFrom: "download"
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: []
+
   download_current_submission:
     run: get_submission.cwl
     in:

--- a/scoring_harness_workflow.cwl
+++ b/scoring_harness_workflow.cwl
@@ -30,6 +30,21 @@ inputs:
 outputs: []
 
 steps:
+
+  set_permissions:
+    run: set_permissions.cwl
+    in:
+      - id: entityid
+        source: "#submitterUploadSynId"
+      # Must update the principal id here
+      - id: principalid
+        valueFrom: "3379097"
+      - id: permissions
+        valueFrom: "download"
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: []
+
   download_submission:
     run: get_submission.cwl
     in:


### PR DESCRIPTION
Adding set permissions into workflow, the log folder is only accessible to the user running the orchestrator and the submitter, so setting the permissions to allow an admin team to access the logs makes it easier to debug models