### PR TITLE
v2.5

### DIFF
--- a/annotate_submission.cwl
+++ b/annotate_submission.cwl
@@ -9,7 +9,7 @@ baseCommand: challengeutils
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/challengeutils:develop
+    dockerPull: sagebionetworks/challengeutils:v1.4.0
 
 requirements:
   - class: InlineJavascriptRequirement
@@ -45,4 +45,3 @@ outputs:
   type: boolean
   outputBinding:
     outputEval: $( true )
-

--- a/annotate_submission.cwl
+++ b/annotate_submission.cwl
@@ -9,7 +9,7 @@ baseCommand: challengeutils
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/challengeutils:v1.4.0
+    dockerPull: sagebionetworks/challengeutils:v1.5.1
 
 requirements:
   - class: InlineJavascriptRequirement
@@ -19,7 +19,7 @@ inputs:
     type: int
   - id: annotation_values
     type: File
-  - id: is_private
+  - id: to_public
     type: boolean?
   - id: force
     type: boolean?
@@ -34,7 +34,7 @@ arguments:
   - valueFrom: annotatesubmission
   - valueFrom: $(inputs.submissionid)
   - valueFrom: $(inputs.annotation_values)
-  - valueFrom: $(inputs.is_private)
+  - valueFrom: $(inputs.to_public)
     prefix: -p
   - valueFrom: $(inputs.force)
     prefix: -f

--- a/annotate_submission.cwl
+++ b/annotate_submission.cwl
@@ -9,7 +9,7 @@ baseCommand: challengeutils
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/challengeutils:v1.3.0
+    dockerPull: sagebionetworks/challengeutils:develop
 
 requirements:
   - class: InlineJavascriptRequirement
@@ -19,9 +19,9 @@ inputs:
     type: int
   - id: annotation_values
     type: File
-  - id: to_public
+  - id: is_private
     type: boolean?
-  - id: force_change_annotation_acl
+  - id: force
     type: boolean?
   - id: synapse_config
     type: File
@@ -34,9 +34,9 @@ arguments:
   - valueFrom: annotatesubmission
   - valueFrom: $(inputs.submissionid)
   - valueFrom: $(inputs.annotation_values)
-  - valueFrom: $(inputs.to_public)
+  - valueFrom: $(inputs.is_private)
     prefix: -p
-  - valueFrom: $(inputs.force_change_annotation_acl)
+  - valueFrom: $(inputs.force)
     prefix: -f
 
 outputs:

--- a/annotate_submission.cwl
+++ b/annotate_submission.cwl
@@ -9,7 +9,7 @@ baseCommand: challengeutils
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/challengeutils:v1.5.1
+    dockerPull: sagebionetworks/challengeutils:v1.5.2
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/docker_agent_workflow.cwl
+++ b/docker_agent_workflow.cwl
@@ -116,9 +116,9 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#validate_docker/results"
-      - id: to_public
-        default: true
-      - id: force_change_annotation_acl
+      - id: is_private
+        default: false
+      - id: force
         default: true
       - id: synapse_config
         source: "#synapseConfig"
@@ -189,9 +189,9 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#upload_results/results"
-      - id: to_public
-        default: true
-      - id: force_change_annotation_acl
+      - id: is_private
+        default: false
+      - id: force
         default: true
       - id: synapse_config
         source: "#synapseConfig"
@@ -235,9 +235,9 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#validation/results"
-      - id: to_public
-        default: true
-      - id: force_change_annotation_acl
+      - id: is_private
+        default: false
+      - id: force
         default: true
       - id: synapse_config
         source: "#synapseConfig"
@@ -286,9 +286,9 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#scoring/results"
-      - id: to_public
-        default: true
-      - id: force_change_annotation_acl
+      - id: is_private
+        default: false
+      - id: force
         default: true
       - id: synapse_config
         source: "#synapseConfig"

--- a/docker_agent_workflow.cwl
+++ b/docker_agent_workflow.cwl
@@ -116,8 +116,8 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#validate_docker/results"
-      - id: is_private
-        default: false
+      - id: to_public
+        default: true
       - id: force
         default: true
       - id: synapse_config
@@ -189,8 +189,8 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#upload_results/results"
-      - id: is_private
-        default: false
+      - id: to_public
+        default: true
       - id: force
         default: true
       - id: synapse_config
@@ -235,8 +235,8 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#validation/results"
-      - id: is_private
-        default: false
+      - id: to_public
+        default: true
       - id: force
         default: true
       - id: synapse_config
@@ -286,8 +286,8 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#scoring/results"
-      - id: is_private
-        default: false
+      - id: to_public
+        default: true
       - id: force
         default: true
       - id: synapse_config

--- a/download_current_lead_submission.cwl
+++ b/download_current_lead_submission.cwl
@@ -20,7 +20,7 @@ arguments:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/challengeutils:v1.3.0
+    dockerPull: sagebionetworks/challengeutils:v1.5.2
 
 inputs:
 

--- a/get_docker_config.cwl
+++ b/get_docker_config.cwl
@@ -9,7 +9,7 @@ baseCommand: python3
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v1.9.2
+    dockerPull: sagebionetworks/synapsepythonclient:v2.0.0
 
 inputs:
   - id: synapse_config

--- a/get_submission.cwl
+++ b/get_submission.cwl
@@ -8,7 +8,7 @@ baseCommand: challengeutils
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/challengeutils:v1.3.0
+    dockerPull: sagebionetworks/challengeutils:v1.5.2
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/ladder_scoring_harness_workflow.cwl
+++ b/ladder_scoring_harness_workflow.cwl
@@ -107,8 +107,8 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#validation/results"
-      - id: is_private
-        default: false
+      - id: to_public
+        default: true
       - id: force
         default: true
       - id: synapse_config
@@ -159,8 +159,8 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#scoring/results"
-      - id: is_private
-        default: false
+      - id: to_public
+        default: true
       - id: force
         default: true
       - id: synapse_config

--- a/ladder_scoring_harness_workflow.cwl
+++ b/ladder_scoring_harness_workflow.cwl
@@ -107,9 +107,9 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#validation/results"
-      - id: to_public
-        default: true
-      - id: force_change_annotation_acl
+      - id: is_private
+        default: false
+      - id: force
         default: true
       - id: synapse_config
         source: "#synapseConfig"
@@ -159,9 +159,9 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#scoring/results"
-      - id: to_public
-        default: true
-      - id: force_change_annotation_acl
+      - id: is_private
+        default: false
+      - id: force
         default: true
       - id: synapse_config
         source: "#synapseConfig"

--- a/run_docker.py
+++ b/run_docker.py
@@ -20,7 +20,7 @@ def create_log_file(log_filename, log_text=None):
             # Convert log_text to str if bytes
             if isinstance(log_text, bytes):
                 log_text = log_text.decode('utf-8')
-            log_file.write(log_text)
+            log_file.write(log_text.encode("ascii", "ignore").decode("ascii"))
         else:
             log_file.write("No Logs")
 

--- a/score_email.cwl
+++ b/score_email.cwl
@@ -82,6 +82,5 @@ requirements:
                   userIds=[participantid],
                   messageSubject=subject,
                   messageBody="".join(message))
-                  #contentType="text")
           
 outputs: []

--- a/score_email.cwl
+++ b/score_email.cwl
@@ -8,7 +8,7 @@ baseCommand: python3
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v1.9.2
+    dockerPull: sagebionetworks/synapsepythonclient:v2.0.0
 
 inputs:
   - id: submissionid
@@ -81,7 +81,7 @@ requirements:
               syn.sendMessage(
                   userIds=[participantid],
                   messageSubject=subject,
-                  messageBody="".join(message),
-                  contentType="text")
+                  messageBody="".join(message))
+                  #contentType="text")
           
 outputs: []

--- a/scoring_harness_workflow.cwl
+++ b/scoring_harness_workflow.cwl
@@ -106,8 +106,8 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#validation/results"
-      - id: is_private
-        default: false
+      - id: to_public
+        default: true
       - id: force
         default: true
       - id: synapse_config
@@ -155,8 +155,8 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#scoring/results"
-      - id: is_private
-        default: false
+      - id: to_public
+        default: true
       - id: force
         default: true
       - id: synapse_config

--- a/scoring_harness_workflow.cwl
+++ b/scoring_harness_workflow.cwl
@@ -106,9 +106,9 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#validation/results"
-      - id: to_public
-        default: true
-      - id: force_change_annotation_acl
+      - id: is_private
+        default: false
+      - id: force
         default: true
       - id: synapse_config
         source: "#synapseConfig"
@@ -155,9 +155,9 @@ steps:
         source: "#submissionId"
       - id: annotation_values
         source: "#scoring/results"
-      - id: to_public
-        default: true
-      - id: force_change_annotation_acl
+      - id: is_private
+        default: false
+      - id: force
         default: true
       - id: synapse_config
         source: "#synapseConfig"

--- a/set_permissions.cwl
+++ b/set_permissions.cwl
@@ -12,7 +12,7 @@ baseCommand: challengeutils
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/challengeutils:v1.3.0
+    dockerPull: sagebionetworks/challengeutils:v1.5.2
 
 inputs:
   - id: entityid

--- a/upload_to_synapse.cwl
+++ b/upload_to_synapse.cwl
@@ -10,7 +10,7 @@ baseCommand: python3
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v1.9.2
+    dockerPull: sagebionetworks/synapsepythonclient:v2.0.0
 
 inputs:
   - id: infile

--- a/validate_docker.cwl
+++ b/validate_docker.cwl
@@ -8,7 +8,7 @@ baseCommand: python3
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v1.9.2
+    dockerPull: sagebionetworks/synapsepythonclient:v2.0.0
 
 inputs:
   - id: docker_repository

--- a/validate_email.cwl
+++ b/validate_email.cwl
@@ -8,7 +8,7 @@ baseCommand: python3
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v1.9.2
+    dockerPull: sagebionetworks/synapsepythonclient:v2.0.0
 
 inputs:
   - id: submissionid
@@ -82,8 +82,7 @@ requirements:
             syn.sendMessage(
               userIds=[participantid],
               messageSubject=subject,
-              messageBody="".join(message),
-              contentType="text")
+              messageBody="".join(message))
 
 outputs:
 - id: finished


### PR DESCRIPTION
* change update_annotation_status parameters
* Fix ascii character issue in docker logs
* Update to v2.0.0 of `synapseclient` and use v1.5.2 of `challengeutils`

This version will contain workflows that will not be backwards compatible with older workflow templates.  specifically the `annotate_submission.cwl` tool.