### PR TITLE
Update status and error annotation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ download_submission:
 
 ### Validation: validate.cwl
 
-This tool can be changed to validate whatever format participants submit their predictions.  It must write results to a JSON file that has keys `prediction_file_status` and `invalid_reasons`.
+This tool can be changed to validate whatever format participants submit their predictions.  It must write results to a JSON file that has keys `submission_status` and `submission_errors`.
 
-* `prediction_file_status`: status of the prediction file - `VALIDATED`, `INVALID`
-* `invalid_reasons`: `\n` joined set of strings that define whatever is wrong with the prediction file (empty string is nothing wrong)
+* `submission_status`: status of the prediction file - `VALIDATED`, `INVALID`
+* `submission_errors`: `\n` joined set of strings that define whatever is wrong with the prediction file (empty string is nothing wrong)
 
 ### Scoring: score.cwl
 
-This tool scores the prediction file against a truth file. It must write results to a JSON file that has keys `prediction_file_status` and `user_defined_score`.
+This tool scores the prediction file against a truth file. It must write results to a JSON file that has keys `submission_status` and user defined score keys.
 
-* `prediction_file_status`: status of the prediction file - `SCORED`
-* `user_defined_score`: This is an annotation that you want to add to the submission, so it should describe what the score is such as `auc`, `aupr`, `f1`, and etc.
+* `submission_status`: status of the prediction file - `SCORED`
+* user defined keys: This is an annotation that you want to add to the submission, so it should describe what the score is such as `auc`, `aupr`, `f1`, and etc.
 
 ### Workflow Steps: scoring_harness_workflow.cwl
 
@@ -55,13 +55,13 @@ annotate_submission:
       source: "#validate_docker/results"
     - id: to_public
       default: true
-    - id: force_change_annotation_acl
+    - id: force
       default: true
     - id: synapse_config
       source: "#synapseConfig"
   out: []
 ```
-The values `to_public` and `force_change_annotation_acl` can be `true` or `false`.  `to_public` controls the ACL of each annotation key passed in during the annotation step, while `force_change_annotation_acl` allows for the same annotation key to change ACLs.  For instance, if the original annotations had annotation `A` that was private, and annotation `A` was passed in again as a public annotation, this would fail the pipeline.  However, passing in `force_change_annotation_acl` as `true` would allow for this change.
+The values `to_public` and `force` can be `true` or `false`.  `to_public` controls the ACL of each annotation key passed in during the annotation step, while `force` allows for the same annotation key to change ACLs.  For instance, if the original annotations had annotation `A` that was private, and annotation `A` was passed in again as a public annotation, this would fail the pipeline.  However, passing in `force` as `true` would allow for this change.
 
 #### Download Synapse File
 
@@ -116,7 +116,6 @@ It is important to notice that the `network_disabled=True` so that submitter mod
 
 ```
 container = client.containers.run(docker_image,
-                                  # 'bash /app/train.sh',
                                   detach=True, volumes=volumes,
                                   name=args.submissionid,
                                   network_disabled=True,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 These are the collection of challenge CWL workflows and tools that can be linked with the [Synapse Workflow Orchestrator](https://github.com/Sage-Bionetworks/SynapseWorkflowOrchestrator).  These are three different challenge workflows:
 
-1. **Classic**: Participants submit prediction files and these files are validated and scored.
+1. **Data to Model**: Participants submit prediction files and these files are validated and scored.
 1. **Model to Data**: Participants submit a docker container with their model, which then runs against internal data and a prediction file is generate.  This prediction file is then validated and scored.
 1. **Ladder Classic**: Participants submit prediction files but these files are compared against leading submissions.
 
@@ -23,7 +23,7 @@ download_submission:
 ...
 ```
 
-## Classic
+## Data to Model
 
 * Workflow: `scoring_harness_workflow.cwl`
 * Recommended tools to edit: `validate.cwl`, `score.cwl`

--- a/score.cwl
+++ b/score.cwl
@@ -44,7 +44,7 @@ requirements:
           args = parser.parse_args()
           score = 3
           prediction_file_status = "SCORED"
-          result = {'score':score, 'prediction_file_status':prediction_file_status}
+          result = {'score':score, 'submission_status':prediction_file_status}
           with open(args.results, 'w') as o:
             o.write(json.dumps(result))
      

--- a/score_email.cwl
+++ b/score_email.cwl
@@ -47,7 +47,7 @@ requirements:
           parser.add_argument("-s", "--submissionid", required=True, help="Submission ID")
           parser.add_argument("-c", "--synapse_config", required=True, help="credentials file")
           parser.add_argument("-r", "--results", required=True, help="Resulting scores")
-          parser.add_argument("-p", "--private_annotaions", nargs="+", default=[], help="annotations to not be sent via e-mail")
+          parser.add_argument("-p", "--private_annotations", nargs="+", default=[], help="annotations to not be sent via e-mail")
 
           args = parser.parse_args()
           syn = synapseclient.Synapse(configPath=args.synapse_config)
@@ -63,13 +63,13 @@ requirements:
           evaluation = syn.getEvaluation(sub.evaluationId)
           with open(args.results) as json_data:
             annots = json.load(json_data)
-          if annots.get('prediction_file_status') is None:
-            raise Exception("score.cwl must return prediction_file_status as a json key")
-          status = annots['prediction_file_status']
+          if annots.get('submission_status') is None:
+            raise Exception("score.cwl must return submission_status as a json key")
+          status = annots['submission_status']
           if status == "SCORED":
-              del annots['prediction_file_status']
+              del annots['submission_status']
               subject = "Submission to '%s' scored!" % evaluation.name
-              for annot in args.private_annotaions:
+              for annot in args.private_annotations:
                 del annots[annot]
               if len(annots) == 0:
                   message = "Your submission has been scored. Results will be announced at a later time."

--- a/score_ladder.cwl
+++ b/score_ladder.cwl
@@ -52,7 +52,8 @@ requirements:
           args = parser.parse_args()
           score = 3
           prediction_file_status = "SCORED"
-          result = {'score':score,'prediction_file_status':prediction_file_status}
+          result = {'score':score,
+                    'submission_status': prediction_file_status}
           with open(args.results, 'w') as o:
             o.write(json.dumps(result))
      

--- a/validate.cwl
+++ b/validate.cwl
@@ -53,7 +53,8 @@ requirements:
               if not message.startswith("test"):
                   invalid_reasons.append("Submission must have test column")
                   prediction_file_status = "INVALID"
-          result = {'prediction_file_errors':"\n".join(invalid_reasons),'prediction_file_status':prediction_file_status}
+          result = {'submission_errors': "\n".join(invalid_reasons),
+                    'submission_status': prediction_file_status}
           with open(args.results, 'w') as o:
               o.write(json.dumps(result))
      
@@ -69,11 +70,11 @@ outputs:
     outputBinding:
       glob: results.json
       loadContents: true
-      outputEval: $(JSON.parse(self[0].contents)['prediction_file_status'])
+      outputEval: $(JSON.parse(self[0].contents)['submission_status'])
 
   - id: invalid_reasons
     type: string
     outputBinding:
       glob: results.json
       loadContents: true
-      outputEval: $(JSON.parse(self[0].contents)['prediction_file_errors'])
+      outputEval: $(JSON.parse(self[0].contents)['submission_errors'])

--- a/validate_docker.cwl
+++ b/validate_docker.cwl
@@ -101,7 +101,8 @@ requirements:
             invalid_reasons.append("Submission must be a Docker image, not Project/Folder/File. Please visit 'Docker Submission' for more information.")
         
           status = "INVALID" if invalid_reasons else "VALID"
-          result = {'docker_image_errors':"\n".join(invalid_reasons),'docker_image_status':status}
+          result = {'submission_errors':"\n".join(invalid_reasons),
+                    'submission_status':status}
           with open(args.results, 'w') as o:
             o.write(json.dumps(result))
 
@@ -117,11 +118,11 @@ outputs:
     outputBinding:
       glob: results.json
       loadContents: true
-      outputEval: $(JSON.parse(self[0].contents)['docker_image_status'])
+      outputEval: $(JSON.parse(self[0].contents)['submission_status'])
 
   - id: invalid_reasons
     type: string
     outputBinding:
       glob: results.json
       loadContents: true
-      outputEval: $(JSON.parse(self[0].contents)['docker_image_errors'])
+      outputEval: $(JSON.parse(self[0].contents)['submission_errors'])

--- a/validate_with_goldstandard.cwl
+++ b/validate_with_goldstandard.cwl
@@ -59,7 +59,8 @@ requirements:
               if not message.startswith("test"):
                   invalid_reasons.append("Submission must have test column")
                   prediction_file_status = "INVALID"
-          result = {'prediction_file_errors':"\n".join(invalid_reasons),'prediction_file_status':prediction_file_status}
+          result = {'submission_errors': "\n".join(invalid_reasons),
+                    'submission_status': prediction_file_status}
           with open(args.results, 'w') as o:
               o.write(json.dumps(result))
      
@@ -75,11 +76,11 @@ outputs:
     outputBinding:
       glob: results.json
       loadContents: true
-      outputEval: $(JSON.parse(self[0].contents)['prediction_file_status'])
+      outputEval: $(JSON.parse(self[0].contents)['submission_status'])
 
   - id: invalid_reasons
     type: string
     outputBinding:
       glob: results.json
       loadContents: true
-      outputEval: $(JSON.parse(self[0].contents)['prediction_file_errors'])
+      outputEval: $(JSON.parse(self[0].contents)['submission_errors'])


### PR DESCRIPTION
Make the status and error keys consistent so that there docker image errors and prediction file errors can all be shown in one column.